### PR TITLE
Fixing last obstinate pep8 message

### DIFF
--- a/upworthyripper.py
+++ b/upworthyripper.py
@@ -78,7 +78,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     parser.add_argument('-l', '--logfile', nargs='?', default='./.upworthyLog',
-            help='file to log any failures to. Default is .upworthyLog in the current directory.')
+                        help='file to log any failures to. Default is '
+                             '.upworthyLog in the current directory.')
 
     parser.add_argument('link', help='Upworthy page to extract content from')
     args = parser.parse_args()


### PR DESCRIPTION
Just fixing up the last pep8 warning. Output from --help message after change:

> (uprip)aoife@odi:~/Projects/Upworthyripper$ python upworthyripper.py --help
> usage: upworthyripper.py [-h] [-l [LOGFILE]] link
> 
> positional arguments:
>   link                  Upworthy page to extract content from
> 
> optional arguments:
>   -h, --help            show this help message and exit
>   -l [LOGFILE], --logfile [LOGFILE]
>                        file to log any failures to. Default is .upworthyLog
>                        in the current directory.
