### PR TITLE
Added requirements including pep8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+argparse==1.2.1
+beautifulsoup4==4.3.2
+pep8==1.5.7


### PR DESCRIPTION
I don't know if this is of any use, but it at least allows someone to set up a virtenv and work with the same versions we use.
